### PR TITLE
Add Console feature

### DIFF
--- a/lib/Devel/ebug/Backend.pm
+++ b/lib/Devel/ebug/Backend.pm
@@ -185,11 +185,15 @@ sub DB::postponed {
     # If this is a subroutine, let postponed_sub() deal with it.
     return &postponed_sub unless ref \$_[0] eq 'GLOB';
 
-    my ($fileName) = @_;
-    $fileName =~ s/^.*_<//;
+    my ($filePath) = @_;
+    $filePath =~ s/^.*_<//;
 
-    if (exists $DB::break_on_load{$fileName}
-      || exists $DB::break_on_load{File::Spec->rel2abs( $fileName)} ){
+    my ($volume,$directories,$fileName) = File::Spec->splitpath( $filePath );
+
+    #test if the file name match with relative path/absolute path/single file name
+    if (exists $DB::break_on_load{$filePath}
+        || exists $DB::break_on_load{File::Spec->rel2abs( $filePath)}
+        || exists $DB::break_on_load{$fileName}){
         $DB::single = 1;
     }
 

--- a/lib/Devel/ebug/Console.pm
+++ b/lib/Devel/ebug/Console.pm
@@ -69,6 +69,7 @@ sub run {
 
       b Set break point at a line number (eg: b 6, b code.pl 6, b code.pl 6 $x > 7,
       b Calc::fib)
+     bf break on file loading (eg: bf Calc.pm)
       d Delete a break point (d 6, d code.pl 6)
       e Eval Perl code and print the result (eg: e $x+$y)
       f Show all the filenames loaded
@@ -130,6 +131,8 @@ restart Restart the program
       $ebug->break_point($1, $2, $3);
     } elsif ($command =~ /^b (.+)/) {
       $ebug->break_point_subroutine($1);
+    } elsif ($command =~ /^bf (.+)/) {
+      $ebug->break_on_load($1);
     } elsif ($command =~ /^d (.+?) (\d+)/) {
       $ebug->break_point_delete($1, $2);
     } elsif ($command =~ /^d (\d+)/) {

--- a/t/breakOnLoad.t
+++ b/t/breakOnLoad.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use lib 'lib';
-use Test::More tests => 3;
+use Test::More tests => 5;
 use Devel::ebug;
 
 my $ebug = Devel::ebug->new;
@@ -19,3 +19,14 @@ is($ebug->filename, "t/Calc.pm");
 $ebug->run;
 is($ebug->finished, 1);
 
+#now same test only the filename without path
+ $ebug = Devel::ebug->new;
+$ebug->program("t/load_calc.pl");
+$ebug->backend("$^X bin/ebug_backend_perl");
+$ebug->load;
+
+$ebug->break_on_load("Calc.pm"); #just provide fileName without path
+
+$ebug->run;
+is($ebug->line, 6);
+is($ebug->filename, "t/Calc.pm");


### PR DESCRIPTION
Hello, I add the break on file loading feature into Console.pm so it's accessible from command line (with th bf command).
For this goal, I added another behaviour so that if you only tape "bf Calc.pm" (filename without any directory before), you will break on every file named Calc.pm whatever their path is. It apears to me to be more convient in Console interface. 
Do you think its ok ?
